### PR TITLE
Remove "Webextension" from title

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,15 @@
 {
 
   "manifest_version": 2,
-  "name": "History in Threads - Webextension",
-  "version": "2.3.2",
+  "name": "History in Threads",
+  "version": "2.3.3",
   "default_locale": "zh",
 
   "description": "Display browsing history in threads.",
 
   "sidebar_action": {
     "default_icon": "icons/icon.png",
-    "default_title" : "History in Threads - Webextension",
+    "default_title" : "History in Threads",
     "default_panel": "sidebar/main.html"
   },
 


### PR DESCRIPTION
All extensions are now Web Extensions, and this was just cluttering up the sidebar.  Thanks!